### PR TITLE
Fix image link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jupyter notebook
 
 The data has three dimensions: latitudinal index, longitudinal index, and temporal index and is arranged in a uniform matrix:
 
-![](https://github.com/NREL/hsds-examples/blob/develop/docs/cube.png)
+![](https://github.com/NREL/hsds-examples/blob/master/docs/cube.png)
 
 The coordinates are thus defined:
 


### PR DESCRIPTION
Looks like the image link (cube.png) in the readme was pointed to the develop branch, which is no longer visible on Github. Changed the link to master branch.