### PR TITLE
Fix version typo in 03_NSRDB_introduction

### DIFF
--- a/notebooks/03_NSRDB_introduction.ipynb
+++ b/notebooks/03_NSRDB_introduction.ipynb
@@ -132,7 +132,7 @@
     }
    ],
    "source": [
-    "f.attrs['version']   # attributes can be used to provide desriptions of the content"
+    "f.attrs['Version']   # attributes can be used to provide desriptions of the content"
    ]
   },
   {


### PR DESCRIPTION
I changed version -> Version since the attribute starts with a capital letter in the dataset